### PR TITLE
fix: problem of workspace configuration loading

### DIFF
--- a/ghostos/bootstrap.py
+++ b/ghostos/bootstrap.py
@@ -94,7 +94,7 @@ def expect_workspace_dir() -> Tuple[str, bool]:
     :return: (workspace dir: str, exists: bool)
     """
     expect_dir = abspath("app")
-    return abspath(expect_dir), exists(expect_dir) and isdir(expect_dir)
+    return expect_dir, exists(expect_dir) and isdir(expect_dir)
 
 
 def app_stub_dir() -> str:

--- a/ghostos/scripts/cli/__init__.py
+++ b/ghostos/scripts/cli/__init__.py
@@ -86,22 +86,18 @@ The Workspace meant to save local files such as configs, logs, cache files.
     ))
 
     conf = get_bootstrap_config(local=False)
-    workspace_dir, ok = expect_workspace_dir()
-    app_dir = workspace_dir.rstrip('/').split("/")[-1]
     result = Prompt.ask(
         f"\n>> will init ghostos workspace at `{getcwd()}`. input directory name:",
-        default=app_dir,
+        default="app",
     )
     source_dir = join(conf.ghostos_dir, "ghostos/app")
     real_workspace_dir = abspath(result)
     console.print("start to init ghostos workspace")
     copy_workspace(source_dir, real_workspace_dir)
     console.print("ghostos workspace copied")
-
-    if conf.workspace_dir != real_workspace_dir:
-        conf.workspace_dir = real_workspace_dir
-        conf.save(getcwd())
-        console.print("save .ghostos.yml")
+    conf.workspace_dir = real_workspace_dir
+    conf.save(real_workspace_dir)
+    console.print("save .ghostos.yml")
     console.print(Panel(Markdown(f"""
 Done create workspace!
 


### PR DESCRIPTION
## 问题描述

ghostos init出workspace，但是配置文件configs/llms_conf.yaml 依然读取的GHOSTOS源代码中的配置而不是workspace的配置。

## 原因

workspace的路径通过目录下`.ghostos.yml`读取，在init命令写入文件时，传入的根路径是`conf.save(getcwd())`，getcwd是执行init命令所在的路径，**也就是workspace的上层目录**，导致`.ghostos.yml`创建在了错误的路径，导致无法读取正确的workspace的配置。

## 修复
`conf.save(getcwd())` 改成 `conf.save(real_workspace_dir)`，同时删除了一些冗余代码。
