### PR TITLE
fix ghostos[realtime] package check

### DIFF
--- a/ghostos/framework/audio/pyaudio_io/speaker.py
+++ b/ghostos/framework/audio/pyaudio_io/speaker.py
@@ -1,8 +1,5 @@
-try:
-    from pyaudio import PyAudio, paInt16
-    from scipy.signal import resample
-except ImportError:
-    raise ImportError(f"Pyaudio is required, please install pyaudio or ghostos[audio] first")
+from pyaudio import PyAudio, paInt16
+from scipy.signal import resample
 
 import numpy as np
 from typing import Callable, Union

--- a/ghostos/prototypes/streamlitapp/pages/chat_with_ghost.py
+++ b/ghostos/prototypes/streamlitapp/pages/chat_with_ghost.py
@@ -248,10 +248,19 @@ def _run_realtime(route: GhostChatRoute, app: RealtimeApp):
 
 
 def get_realtime_app(conversation: Conversation) -> Optional[RealtimeApp]:
-    try:
-        import pyaudio
-    except ImportError:
-        return None
+    # 获取并检查 realtime extras 的所有依赖是否已安装
+    from importlib.metadata import distribution
+    dist = distribution('ghostos')
+    requires = dist.requires or []
+    realtime_requires = [r for r in requires if 'extra == "realtime"' in r]
+    # 如果所有依赖都已安装，importlib.metadata 就能找到它们
+    for pkg in realtime_requires:
+        # 从依赖字符串中提取包名（去掉版本和其他限制条件）
+        pkg_name = pkg.split()[0]
+        try:
+            distribution(pkg_name)
+        except ModuleNotFoundError:
+            return None
 
     from ghostos.framework.audio import get_pyaudio_pcm16_speaker, get_pyaudio_pcm16_listener
     from ghostos.framework.openai_realtime import get_openai_realtime_app


### PR DESCRIPTION
ghostos[realtime] 依赖了多个python包，但是在get_realtime_app时只校验了pyaudio，如果scipy没有安装，那么会抛出错误，错误信息也有些问题（ghostos[realtime] 而不是 ghostos[audio]）。

这里优化了下依赖包的校验方法，保证所有定义在pyproject.yaml中的realtime依赖包都能被校验，确保安装成功。