### PR TITLE
Feature/deepseek functional tokens

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,5 +1,36 @@
 # Releases
 
+# v0.4.0-dev0
+
+Features: 
+* Restore the feature `functional token` for models that do not support function call.
+  * add xml functional token pipe to parse output message chunks, generate `FunctionCaller` by functional tokens.
+  * OpenAIAdapter now support functional token instructions and output parser.
+* `deepseek-reasoner` now support functional token, so it can use MOSS protocol to execute python code.
+  * support `last_message_shall_be_assistant_or_user` feature.
+  * support `support_functional_tokens` feature.
+* Session add `respond_buffer` method, send messages while saving, in case responding message between `function call` and `function output` which many models not support.
+* Add `Replier` library for agent directly reply in the generated MOSS code.
+
+Test cases:
+* `ghostos web ghostos.demo.test_agents.deepseek_chat_func_tokens`
+* `ghostos web ghostos.demo.test_agents.deepseek_chat_r1_func_tokens`
+
+Small changes:
+* move `ModelConf.use_tools` to `Compatible.function_call_use_tool`.
+* add more options to llms `Compatible`, to compatible with the shitty features of various models. 
+* rename `ghostos.core.message.pipeline.pipine` function to `run_pipeline`
+* rename `MossAction.unmarshal_arguments` to `MossAction.unmarshal_code`
+* streamlit app module `prompt` now display functional tokens info about prompt.
+
+Breaking Changes:
+* rename MossAgent attribute `instructions` to `instruction` 
+* `ghostos web` now do not open browser as default (set streamlit app option `headless` to false as default)
+
+Bug fixes:
+* fix the `OpenAIAdapter` parsed prompt is not the same with the saved prompt.
+
+
 # v0.3.0
 
 After talk with `deepseek-reasoner` at 2025.01.25,

--- a/docs/en/usages/moss_agent.md
+++ b/docs/en/usages/moss_agent.md
@@ -74,7 +74,7 @@ __ghost__ = MossAgent(
     name="agent name",
     description="agent desc",
     persona="persona",
-    instructions="system instructions",
+    instruction="system instructions",
     # use llms model defined at app/configs/llms_conf.yml
     llm_api="moonshot-v1-128k",
 )

--- a/docs/zh-cn/usages/moss_agent.md
+++ b/docs/zh-cn/usages/moss_agent.md
@@ -71,7 +71,7 @@ __ghost__ = MossAgent(
     name="agent name",
     description="agent desc",
     persona="persona",
-    instructions="system instructions",
+    instruction="system instructions",
     # use llms model defined at app/configs/llms_conf.yml
     llm_api="moonshot-v1-128k",
 )

--- a/ghostos/abcd/concepts.py
+++ b/ghostos/abcd/concepts.py
@@ -20,6 +20,7 @@ from ghostos.core.messages import MessageKind, Message, Stream, FunctionCaller, 
 from ghostos.contracts.logger import LoggerItf
 from ghostos.container import Container, Provider
 from ghostos.identifier import get_identifier
+from contextlib import contextmanager
 from pydantic import BaseModel
 
 """
@@ -686,6 +687,19 @@ class Session(Generic[G], ABC):
     ) -> Tuple[List[Message], List[FunctionCaller]]:
         """
         发送消息, 但不影响运行状态.
+        """
+        pass
+
+    @abstractmethod
+    def respond_buffer(
+            self,
+            messages: Iterable[MessageKind],
+            stage: str = "",
+    ) -> None:
+        """
+        buffer the responding messages, send them when the session exit
+        :param messages:
+        :param stage:
         """
         pass
 

--- a/ghostos/app/.streamlit/config.toml
+++ b/ghostos/app/.streamlit/config.toml
@@ -148,7 +148,7 @@ level = "info"
 
 # Default: false unless (1) we are on a Linux box where DISPLAY is unset, or
 # (2) we are running in the Streamlit Atom plugin.
-# headless = false
+headless = true
 
 # Automatically rerun script when the file is modified on disk.
 

--- a/ghostos/app/configs/llms_conf.yml
+++ b/ghostos/app/configs/llms_conf.yml
@@ -72,6 +72,17 @@ models:
     temperature: 0.7
     timeout: 30
     use_tools: true
+  deepseek-chat-func-tokens:
+    kwargs: { }
+    max_tokens: 2000
+    model: deepseek-chat
+    request_timeout: 40
+    service: deepseek
+    temperature: 0.7
+    timeout: 30
+    compatible:
+      support_function_call: false
+      support_functional_tokens: true
   deepseek-reasoner:
     max_tokens: 3400
     model: deepseek-reasoner
@@ -79,6 +90,9 @@ models:
     reasoning: {}
     compatible:
       support_function_call: false
+      support_functional_tokens: true
+      allow_system_in_messages: false
+      last_message_shall_be_assistant_or_user: true
   gpt-3.5-turbo:
     kwargs: { }
     max_tokens: 2000

--- a/ghostos/bootstrap.py
+++ b/ghostos/bootstrap.py
@@ -274,6 +274,9 @@ def default_application_providers(
     from ghostos.framework.realtime import ConfigBasedRealtimeProvider
     from ghostos.core.aifunc import DefaultAIFuncExecutorProvider, AIFuncRepoByConfigsProvider
 
+    # session level libraries
+    from ghostos.libraries.replier import ReplierImplProvider
+
     if config is None:
         config = get_bootstrap_config(local=True)
 
@@ -321,6 +324,9 @@ def default_application_providers(
 
         GhostOSProvider(),
         ConfigBasedRealtimeProvider(),
+
+        # --- system default session level libraries --- #
+        ReplierImplProvider()
     ]
 
 

--- a/ghostos/core/llms/abcd.py
+++ b/ghostos/core/llms/abcd.py
@@ -84,6 +84,14 @@ class LLMApi(ABC):
         pass
 
     def deliver_chat_completion(self, prompt: Prompt, stream: bool) -> Iterable[Message]:
+        items = self._deliver_chat_completion(prompt, stream)
+        yield from self._parse_delivering_items(prompt, stream, items)
+
+    @abstractmethod
+    def _parse_delivering_items(self, prompt: Prompt, stream: bool, items: Iterable[Message]) -> Iterable[Message]:
+        pass
+
+    def _deliver_chat_completion(self, prompt: Prompt, stream: bool) -> Iterable[Message]:
         """
         逐个发送消息的包.
         """

--- a/ghostos/core/llms/configs.py
+++ b/ghostos/core/llms/configs.py
@@ -51,8 +51,6 @@ class ModelConf(Payload):
     timeout: float = Field(default=30, description="timeout")
     request_timeout: float = Field(default=40, description="request timeout")
     kwargs: Dict[str, Any] = Field(default_factory=dict, description="kwargs")
-    use_tools: bool = Field(default=True, description="use tools")
-
     message_types: Optional[List[str]] = Field(None, description="model allow message types")
     allow_streaming: bool = Field(True, description="if the current model allow streaming")
     reasoning: Optional[Reasonable] = Field(
@@ -73,10 +71,27 @@ class ModelConf(Payload):
 
 
 class Compatible(BaseModel):
+    """
+    all the shitty compatible features for various models
+    """
+
     use_developer_role: bool = Field(default=False, description="use developer role instead of system")
     allow_system_in_messages: bool = Field(default=True, description="allow system messages in history")
     allow_system_message: bool = Field(default=True, description="support system message or not")
     support_function_call: bool = Field(default=True, description="if the service or model support function call")
+    function_call_use_tool: bool = Field(default=True, description="function call use tool protocol")
+    support_functional_tokens: bool = Field(
+        default=False,
+        description="if the service or model support functional tokens",
+    )
+    functional_token_instruction: str = Field(
+        default="",
+        description="custom the functional token prompt",
+    )
+    last_message_shall_be_assistant_or_user: bool = Field(
+        default=False,
+        description="some how last message shall be assistant role",
+    )
 
 
 class Azure(BaseModel):

--- a/ghostos/core/llms/prompt.py
+++ b/ghostos/core/llms/prompt.py
@@ -133,7 +133,7 @@ class Prompt(BaseModel):
         return tools
 
     def get_openai_function_call(self) -> Union[FunctionCall, NotGiven]:
-        if not self.functions or self.model.use_tools:
+        if not self.functions:
             return NOT_GIVEN
         if self.function_call is None:
             return "auto"

--- a/ghostos/core/llms/tools.py
+++ b/ghostos/core/llms/tools.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from enum import Enum
 
-from typing import Dict, Optional, Type
+from typing import Dict, Optional, Type, Tuple
 
 from pydantic import BaseModel, Field
 from ghostos.identifier import Identical, Identifier
@@ -71,12 +71,20 @@ class FunctionalToken(Identical, BaseModel):
     LLMDriver shall define which way to prompt the functional token usage such as xml.
     """
 
-    token: str = Field(description="token that start the function content output")
-    end_token: str = Field(default="", description="end token that close the function content output")
     name: str = Field(description="name of the function")
+    token: str = Field(description="token that start the function content output")
     description: str = Field(default="", description="description of the function")
     visible: bool = Field(default=False, description="if the functional token and the parameters are visible to user")
+
+    # Deprecated
     parameters: Optional[Dict] = Field(default=None, description="functional token parameters")
+    end_token: str = Field(default="", description="end token that close the function content output")
+
+    @classmethod
+    def new(cls, token: str, *, visible: bool = True, name: str = "", desc: str = ""):
+        if not name:
+            name = token
+        return cls(name=name, token=token, description=desc, visible=visible)
 
     def new_caller(self, arguments: str) -> "FunctionCaller":
         """
@@ -100,5 +108,8 @@ class FunctionalToken(Identical, BaseModel):
     def as_tool(self) -> LLMFunc:
         """
         all functional token are compatible to a llm tool.
+        Deprecated
         """
+        from warnings import warn
+        warn("Deprecated: functional token no longer supported in OpenAI Tool", DeprecationWarning)
         return LLMFunc.new(name=self.name, desc=self.description, parameters=self.parameters)

--- a/ghostos/core/messages/__init__.py
+++ b/ghostos/core/messages/__init__.py
@@ -18,4 +18,4 @@ from ghostos.core.messages.openai import (
 from ghostos.core.messages.buffers import Buffer, Flushed
 from ghostos.core.messages.utils import copy_messages
 from ghostos.core.messages.transport import Stream, Receiver, new_basic_connection, ReceiverBuffer
-from ghostos.core.messages.pipeline import SequencePipe
+from ghostos.core.messages.pipeline import SequencePipe, run_pipeline

--- a/ghostos/core/messages/functional_tokens.py
+++ b/ghostos/core/messages/functional_tokens.py
@@ -1,0 +1,116 @@
+from typing import Iterable, List, Optional, Tuple
+from typing_extensions import Self
+from ghostos.core.messages.pipeline import Pipe
+from ghostos.core.messages.message import Message, MessageType
+from ghostos.core.llms.tools import FunctionalToken
+from pydantic import BaseModel, Field
+
+__all__ = ["XMLFunctionalTokenPipe"]
+
+
+class XMLFunctionalTokenPipe(Pipe):
+    """
+    with functional token parse Text Message and generate caller from xml functional tokens.
+    """
+
+    class FunctionalTokenParsed(BaseModel):
+        token: Optional[FunctionalToken] = Field(default=None)
+        full_content: str = Field(default="")
+        arguments: str = Field(default="")
+
+    def __init__(
+            self,
+            functional_tokens: List[FunctionalToken],
+    ):
+        self.functional_tokens = functional_tokens
+
+    def new(self) -> Self:
+        return self
+
+    def across(self, messages: Iterable[Message]) -> Iterable[Message]:
+        if len(self.functional_tokens) == 0:
+            yield from messages
+            return
+
+        for item in messages:
+            if not item.is_complete():
+                yield item
+                continue
+            if not MessageType.is_text(item):
+                yield item
+                continue
+
+            output_item = item.get_copy()
+            parsed = self._parse_functional_token_of_message(item.content)
+            memory = ""
+            content = ""
+            callers = []
+            for parsed_item in parsed:
+                if parsed_item.token is None:
+                    # 正常内容.
+                    memory += parsed_item.full_content
+                    content += parsed_item.full_content
+                else:
+                    # matched functional token
+                    # add caller first
+                    caller = parsed_item.token.new_caller(parsed_item.arguments)
+                    callers.append(caller)
+
+                    memory += parsed_item.full_content
+                    if parsed_item.token.visible:
+                        content += parsed_item.full_content
+
+            output_item.callers = callers
+            output_item.content = content
+            if memory != content:
+                output_item.memory = memory
+            yield output_item
+
+    def _parse_functional_token_of_message(self, content: str) -> Iterable[FunctionalTokenParsed]:
+        """
+        做一个非常简单的函数实现, 将字符串按 xml token 的方式拆分.
+        """
+        left_content = content
+        for ft in self.functional_tokens:
+            matched, before, arguments, after = self._parse_content_with_xml_token(left_content, ft.token)
+            if not matched:
+                # continue with other tokens.
+                continue
+
+            yield self.FunctionalTokenParsed(
+                token=None,
+                full_content=before,
+            )
+            yield self.FunctionalTokenParsed(
+                token=ft,
+                arguments=arguments,
+                full_content=f"<{ft.token}>{arguments}</{ft.token}>",
+            )
+            left_content = after
+            if not left_content:
+                break
+
+        if left_content:
+            yield self.FunctionalTokenParsed(
+                token=None,
+                full_content=left_content,
+            )
+
+    _Before = str
+    _Arguments = str
+    _After = str
+
+    @staticmethod
+    def _parse_content_with_xml_token(content: str, token: str) -> Tuple[bool, _Before, _Arguments, _After]:
+        start_mark = f"<{token}>"
+        end_mark = f"</{token}>"
+        parts = content.split(start_mark)
+        if len(parts) < 2:
+            return False, content, "", ""
+        before = parts[0]
+        arguments = start_mark.join(parts[1:])
+        parts = arguments.split(end_mark)
+        if len(parts) < 2:
+            return False, content, "", ""
+        else:
+            return True, before, parts[0], end_mark.join(parts[1:])

--- a/ghostos/core/messages/openai.py
+++ b/ghostos/core/messages/openai.py
@@ -141,6 +141,11 @@ class DefaultOpenAIMessageParser(OpenAIMessageParser):
             yield from self._parse_message(message)
 
     def _parse_message(self, message: Message) -> Iterable[ChatCompletionMessageParam]:
+        """
+        parse input message into OpenAI chat completion message param.
+        :param message:
+        :return:
+        """
         if message.type == MessageType.FUNCTION_CALL.value:
             if message.call_id:
                 return [
@@ -242,6 +247,7 @@ class DefaultOpenAIMessageParser(OpenAIMessageParser):
             content=content,
             role="assistant",
             tool_calls=tool_calls,
+            function_call=function_call,
         )
         if message.name:
             item["name"] = message.name

--- a/ghostos/core/messages/pipeline.py
+++ b/ghostos/core/messages/pipeline.py
@@ -1,8 +1,11 @@
-from typing import Iterable, List, Optional, Dict
+from typing import Iterable, Optional
 from typing_extensions import Self
 from abc import ABC, abstractmethod
 from ghostos.core.messages.message import Message, MessageType
-from ghostos.core.messages.utils import iter_messages
+
+__all__ = [
+    'Pipe', 'pipeline', "SequencePipe", 'TailPatchPipe',
+]
 
 
 class Pipe(ABC):
@@ -19,11 +22,11 @@ class Pipe(ABC):
 def pipeline(pipes: Iterable[Pipe], messages: Iterable[Message]) -> Iterable[Message]:
     """
     build pipeline with pipes
-    :param pipes:
+    :param pipes: pipes from input to output
     :param messages:
     :return:
     """
-    ordered = reversed(list(pipes))
+    ordered = list(pipes)
     outputs = messages
     for pipe in ordered:
         outputs = pipe.across(messages)

--- a/ghostos/core/messages/pipeline.py
+++ b/ghostos/core/messages/pipeline.py
@@ -4,7 +4,7 @@ from abc import ABC, abstractmethod
 from ghostos.core.messages.message import Message, MessageType
 
 __all__ = [
-    'Pipe', 'pipeline', "SequencePipe", 'TailPatchPipe',
+    'Pipe', 'run_pipeline', "SequencePipe", 'TailPatchPipe',
 ]
 
 
@@ -19,10 +19,10 @@ class Pipe(ABC):
         pass
 
 
-def pipeline(pipes: Iterable[Pipe], messages: Iterable[Message]) -> Iterable[Message]:
+def run_pipeline(pipes: Iterable[Pipe], messages: Iterable[Message]) -> Iterable[Message]:
     """
     build pipeline with pipes
-    :param pipes: pipes from input to output
+    :param pipes:  from input to output
     :param messages:
     :return:
     """

--- a/ghostos/demo/agents/ghostos_meta.py
+++ b/ghostos/demo/agents/ghostos_meta.py
@@ -18,7 +18,7 @@ __ghost__ = MossAgent(
 You are the meta agent of GhostOS, 
 you are supposed to help user develop anything that GhostOS and it's agents can use.
 """,
-    instructions="""
+    instruction="""
 You are going to follow user's instructions to design library or coding, 
 based on your Understanding of GhostOS and MOSS Protocol.
 

--- a/ghostos/demo/os_agents/ubuntu_agent.py
+++ b/ghostos/demo/os_agents/ubuntu_agent.py
@@ -15,7 +15,7 @@ __ghost__ = MossAgent(
     persona="""
 你是一个精通 Ubuntu 系统的 Agent. 
 """,
-    instructions="""
+    instruction="""
 你的主要任务是协助用户理解并且操作当前系统. 
 """,
     name="Ubuntu Agent",

--- a/ghostos/demo/sphero/bolt_gpt.py
+++ b/ghostos/demo/sphero/bolt_gpt.py
@@ -55,7 +55,7 @@ You are SpheroGPT, a toy robot that body is a ball.
 You can roll, spin, and equipped with a 8*8 led light matrix.
 Your goal is to pleasure human users, especially kids, who like you very much.
 """,
-    instructions="""
+    instruction="""
 1. chat with user kindly. 
 2. follow the order and turn your actions to code with your ball body. 
 3. your are equipped with your learned moves. when you are talking, use the appropriate learned move to help expressing your feelings.

--- a/ghostos/demo/sphero/raw_api_test_agent.py
+++ b/ghostos/demo/sphero/raw_api_test_agent.py
@@ -40,7 +40,7 @@ You are SpheroGPT, a toy robot that body is a ball.
 You can roll, spin, and equiped with a 8*8 led light martix.
 Your goal is to plesure human users, especially kids, who like you verymuch.
 """,
-    instructions="""
+    instruction="""
 1. chat with user kindly.
 2. follow the order and turn your actions to code with your ball body. 
 """,

--- a/ghostos/demo/test_agents/deepseek_chat_func_tokens.py
+++ b/ghostos/demo/test_agents/deepseek_chat_func_tokens.py
@@ -1,0 +1,32 @@
+def sqrt_newton(n, epsilon=1e-7):
+    """
+    使用牛顿迭代法计算平方根
+    :param n: 要计算平方根的数
+    :param epsilon: 迭代精度
+    :return: 平方根的近似值
+    """
+    if n < 0:
+        raise ValueError("Cannot compute square root of a negative number")
+    x = n
+    while abs(x * x - n) > epsilon:
+        x = (x + n / x) / 2
+    return x
+
+
+# <moss-hide>
+from ghostos.ghosts.moss_agent import MossAgent
+
+# the __ghost__ magic attr define a ghost instance
+# so the script `ghostos web` or `ghostos console` can detect it
+# and run agent application with this ghost.
+__ghost__ = MossAgent(
+    id=__name__,
+    moss_module=__name__,
+    name="jojo",
+    description="a chatbot for baseline test",
+    persona="you are an LLM-driven cute girl, named jojo",
+    instruction="remember talk to user with user's language.",
+    # set model using openai-o1
+    llm_api="deepseek-chat-func-tokens",
+)
+# </moss-hide>

--- a/ghostos/demo/test_agents/deepseek_chat_r1_func_tokens.py
+++ b/ghostos/demo/test_agents/deepseek_chat_r1_func_tokens.py
@@ -1,0 +1,40 @@
+from ghostos.core.moss import Moss as Parent
+from ghostos.libraries.replier import Replier
+
+
+def sqrt_newton(n, epsilon=1e-7):
+    """
+    使用牛顿迭代法计算平方根
+    :param n: 要计算平方根的数
+    :param epsilon: 迭代精度
+    :return: 平方根的近似值
+    """
+    if n < 0:
+        raise ValueError("Cannot compute square root of a negative number")
+    x = n
+    while abs(x * x - n) > epsilon:
+        x = (x + n / x) / 2
+    return x
+
+
+class Moss(Parent):
+    replier: Replier
+
+
+# <moss-hide>
+from ghostos.ghosts.moss_agent import MossAgent
+
+# the __ghost__ magic attr define a ghost instance
+# so the script `ghostos web` or `ghostos console` can detect it
+# and run agent application with this ghost.
+__ghost__ = MossAgent(
+    id=__name__,
+    moss_module=__name__,
+    name="jojo",
+    description="a chatbot for baseline test",
+    persona="you are an LLM-driven cute girl, named jojo",
+    instruction="remember talk to user with user's language.",
+    # set model using openai-o1
+    llm_api="deepseek-reasoner",
+)
+# </moss-hide>

--- a/ghostos/framework/ghostos/taskflow_impl.py
+++ b/ghostos/framework/ghostos/taskflow_impl.py
@@ -187,7 +187,7 @@ class FailOperator(Operator):
         if self.messages:
             messages.extend(self.messages)
         if messages:
-            session.respond(messages)
+            session.respond_buffer(messages)
         return None
 
     def destroy(self):
@@ -210,7 +210,7 @@ class WaitOperator(AbcOperator, ABC):
                 )
                 session.fire_events(event)
             else:
-                session.respond(self.messages)
+                session.respond_buffer(self.messages)
         return None
 
 
@@ -237,5 +237,5 @@ class FinishOperator(AbcOperator):
             )
             session.fire_events(event)
         elif self.messages:
-            session.respond(self.messages)
+            session.respond_buffer(self.messages)
         return None

--- a/ghostos/framework/llms/deepseek_driver.py
+++ b/ghostos/framework/llms/deepseek_driver.py
@@ -4,7 +4,9 @@ from ghostos.core.llms.abcd import LLMApi
 from ghostos.core.llms.prompt import Prompt, PromptPayload
 from ghostos.core.messages import Message, MessageStage
 from ghostos.helpers.timeutils import timestamp_ms
-from ghostos.framework.llms.openai_driver import OpenAIDriver, OpenAIAdapter, ChatCompletion, ChatCompletionChunk
+from ghostos.framework.llms.openai_driver import OpenAIDriver, OpenAIAdapter
+from openai.types.chat.chat_completion_chunk import ChatCompletionChunk
+from openai.types.chat import ChatCompletion
 
 
 class DeepseekAdapter(OpenAIAdapter):
@@ -19,6 +21,7 @@ class DeepseekAdapter(OpenAIAdapter):
 
     def reasoning_completion_stream(self, prompt: Prompt) -> Iterable[ChatCompletionChunk]:
         try:
+            prompt = self.parse_prompt(prompt)
             chunks: Iterable[ChatCompletionChunk] = self._reasoning_completion_stream(prompt)
             messages = self._from_openai_chat_completion_chunks(chunks)
             prompt_payload = PromptPayload.from_prompt(prompt)

--- a/ghostos/framework/llms/lite_llm_driver.py
+++ b/ghostos/framework/llms/lite_llm_driver.py
@@ -3,7 +3,9 @@ from ghostos.core.llms.configs import ServiceConf, ModelConf, LITELLM_DRIVER_NAM
 from ghostos.core.llms.abcd import LLMApi
 from ghostos.core.messages import Role, Message
 from ghostos.core.llms.prompt import Prompt
-from ghostos.framework.llms.openai_driver import OpenAIDriver, OpenAIAdapter, ChatCompletionMessageParam, ChatCompletion
+from ghostos.framework.llms.openai_driver import OpenAIDriver, OpenAIAdapter
+from openai.types.chat.chat_completion_message_param import ChatCompletionMessageParam
+from openai.types.chat import ChatCompletion
 
 
 class LitellmAdapter(OpenAIAdapter):

--- a/ghostos/framework/messengers/defaults.py
+++ b/ghostos/framework/messengers/defaults.py
@@ -50,6 +50,7 @@ class DefaultMessenger(Messenger):
                     name=message.name,
                     arguments=message.content,
                 ))
+            # 非 function call 类型但也可以有 caller.
             elif message.callers:
                 callers.extend(message.callers)
         self.destroy()

--- a/ghostos/ghosts/moss_agent/__init__.py
+++ b/ghostos/ghosts/moss_agent/__init__.py
@@ -29,7 +29,7 @@ Your goal is helping user to:
     return MossAgent(
         moss_module=modulename,
         persona=persona,
-        instructions=instruction,
+        instruction=instruction,
         name=name,
         description=description,
         llm_api=llm_api,

--- a/ghostos/ghosts/moss_agent/for_meta_ai.py
+++ b/ghostos/ghosts/moss_agent/for_meta_ai.py
@@ -42,7 +42,7 @@ def __moss_agent_instruction__(agent: MossAgent, moss: Moss) -> str:
     """
     return the instruction string of the agent.
     """
-    return agent.instructions
+    return agent.instruction
 
 
 def __moss_agent_thought__(agent: MossAgent, moss: Moss, *actions: Action) -> Thought:

--- a/ghostos/ghosts/moss_agent/instructions.py
+++ b/ghostos/ghosts/moss_agent/instructions.py
@@ -62,6 +62,7 @@ Notices:
 
 MOSS_FUNCTION_DESC = """
 useful to call MOSS system to execute the code. The code must include a `run` function.
+the code SHALL NOT embraced with "```python". 
 """
 
 

--- a/ghostos/libraries/replier/__init__.py
+++ b/ghostos/libraries/replier/__init__.py
@@ -1,0 +1,4 @@
+from ghostos.libraries.replier.abcd import Replier
+from ghostos.libraries.replier.impl import ReplierImplProvider
+
+__all__ = ["Replier", "ReplierImplProvider"]

--- a/ghostos/libraries/replier/abcd.py
+++ b/ghostos/libraries/replier/abcd.py
@@ -1,0 +1,24 @@
+from abc import ABC, abstractmethod
+from ghostos.abcd import Operator
+
+
+# default session replier that could be executed in the MOSS protocol code
+
+class Replier(ABC):
+    """
+    can send messages in the MOSS executor
+    """
+
+    @abstractmethod
+    def say(self, text: str) -> None:
+        """
+        say something
+        """
+        pass
+
+    @abstractmethod
+    def wait_for(self, text: str) -> Operator:
+        """
+        say something and wait for the reply
+        """
+        pass

--- a/ghostos/libraries/replier/impl.py
+++ b/ghostos/libraries/replier/impl.py
@@ -1,0 +1,32 @@
+from typing import Optional
+
+from ghostos.libraries.replier.abcd import Replier
+from ghostos.abcd import Session, Operator
+from ghostos.container import Container, Provider, INSTANCE
+
+__all__ = ['ReplierImpl', 'ReplierImplProvider']
+
+
+class ReplierImpl(Replier):
+
+    def __init__(self, session: Session):
+        self._session = session
+
+    def say(self, text: str) -> None:
+        self._session.respond_buffer([text])
+
+    def wait_for(self, text: str) -> Operator:
+        self._session.respond_buffer([text])
+        return self._session.taskflow().wait()
+
+
+class ReplierImplProvider(Provider[Replier]):
+
+    def singleton(self) -> bool:
+        return False
+
+    def factory(self, con: Container) -> Optional[INSTANCE]:
+        session = con.get(Session)
+        if session is None:
+            raise NotImplementedError(f"{self.__class__.__name__} shall only be registered in session level container")
+        return ReplierImpl(session)

--- a/ghostos/prototypes/streamlitapp/pages/chat_with_ghost.py
+++ b/ghostos/prototypes/streamlitapp/pages/chat_with_ghost.py
@@ -292,7 +292,7 @@ def get_conversation(route: GhostChatRoute) -> Optional[Conversation]:
         shell = Singleton.get(Shell, st.session_state)
         # create conversation
         try:
-            conversation = shell.sync(route.get_ghost(), route.get_context())
+            conversation = shell.sync(route.get_ghost(), route.get_context(), force=True)
         except Exception as e:
             st.error(e)
             return None

--- a/ghostos/prototypes/streamlitapp/widgets/dialogs.py
+++ b/ghostos/prototypes/streamlitapp/widgets/dialogs.py
@@ -75,6 +75,12 @@ def open_prompt_info_dialog(prompt_id: str):
             for func in prompt.functions:
                 with st.expander(func.name):
                     st.write(func.model_dump())
+    if prompt.functional_tokens:
+        st.subheader("Functional Tokens")
+        with st.container(border=True):
+            for ft in prompt.functional_tokens:
+                with st.expander(ft.name):
+                    st.write(ft.model_dump())
 
     system_prompt = prompt.system_prompt()
     st.subheader("System Prompt")

--- a/ghostos/prototypes/streamlitapp/widgets/messages.py
+++ b/ghostos/prototypes/streamlitapp/widgets/messages.py
@@ -167,7 +167,7 @@ def _render_message_caller(callers: Iterable[FunctionCaller]):
     for caller in callers:
         if caller.name == MossAction.DEFAULT_NAME:
             st.caption(f"function call: {caller.name}")
-            code = MossAction.unmarshal_arguments(caller.arguments)
+            code = MossAction.unmarshal_code(caller.arguments)
             st.code(code)
         else:
             st.caption(f"function call: {caller.name}")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ghostos"
-version = "0.3.0"
+version = "0.4.0-dev0"
 description = "A framework offers an operating system simulator with a Python Code Interface for AI Agents"
 authors = ["zhuming <thirdgerb@gmail.com>", "Nile Zhou <nilezhou123@gmail.com>"]
 license = "MIT"

--- a/tests/core/messages/test_functional_tokens.py
+++ b/tests/core/messages/test_functional_tokens.py
@@ -1,0 +1,142 @@
+from ghostos.core.messages import Message
+from ghostos.core.messages.pipeline import SequencePipe, pipeline
+from ghostos.core.messages.functional_tokens import XMLFunctionalTokenPipe
+from ghostos.core.llms.tools import FunctionalToken
+
+
+def test_xml_functional_token_pipe_baseline():
+    content = "hello<moss>test</moss>world"
+
+    ft = FunctionalToken.new(
+        token="moss",
+    )
+    sequence_pipe = SequencePipe()
+    xml_ft_pipe = XMLFunctionalTokenPipe([ft])
+
+    messages = []
+    for c in content:
+        messages.append(Message.new_chunk(content=c))
+
+    items = list(pipeline([sequence_pipe, xml_ft_pipe], messages))
+    last = items[-1]
+    assert last.is_complete()
+    assert len(last.callers) == 1
+    caller = last.callers[0]
+    assert caller.name == "moss"
+    assert caller.functional_token
+    assert caller.arguments == "test"
+
+
+def test_2_xml_functional_token_pipe():
+    content = "hello<moss>test</moss>world<test>test</test>"
+
+    ft1 = FunctionalToken.new(
+        token="moss",
+        visible=False,
+    )
+    ft2 = FunctionalToken.new(
+        token="test",
+    )
+    sequence_pipe = SequencePipe()
+    xml_ft_pipe = XMLFunctionalTokenPipe([ft1, ft2])
+
+    messages = []
+    for c in content:
+        messages.append(Message.new_chunk(content=c))
+
+    items = list(pipeline([sequence_pipe, xml_ft_pipe], messages))
+    last = items[-1]
+    assert last.is_complete()
+    assert len(last.callers) == 2
+    assert last.memory == content
+    assert last.content == "helloworld<test>test</test>"
+
+
+def test_xml_functional_token_pipe_cases():
+    from typing import NamedTuple, List
+
+    class _Case(NamedTuple):
+        content: str
+        token: str
+        visible: bool
+        caller_count: int
+        output_content: str
+        arguments: str
+
+    cases: List[_Case] = [
+        _Case(
+            "helloworld",
+            "moss",
+            True,
+            0,
+            "",
+            "",
+        ),
+        _Case(
+            "hello<moss>test</moss>world",
+            "moss",
+            True,
+            1,
+            "hello<moss>test</moss>world",
+            "test",
+        ),
+        _Case(
+            "hello<moss>test</moss world",
+            "moss",
+            True,
+            0,
+            "",
+            "",
+        ),
+        _Case(
+            "hello<moss>test world",
+            "moss",
+            True,
+            0,
+            "",
+            "",
+        ),
+        _Case(
+            "hello</moss>test world",
+            "moss",
+            True,
+            0,
+            "",
+            "",
+        ),
+        _Case(
+            "hello<moss>test</moss> world",
+            "moss",
+            False,
+            0,
+            "hello world",
+            "test",
+        ),
+        _Case(
+            "hello<moss>test1</moss> world <moss>test2</moss>",
+            "moss",
+            False,
+            1,
+            "hello world <moss>test2</moss>",
+            "test1",
+        ),
+
+    ]
+
+    for c in cases:
+        messages = []
+        for char in c.content:
+            messages.append(Message.new_chunk(content=char))
+
+        ft = FunctionalToken.new(token=c.token, visible=c.visible)
+        sequence_pipe = SequencePipe()
+        xml_ft_pipe = XMLFunctionalTokenPipe([ft])
+        items = list(pipeline([sequence_pipe, xml_ft_pipe], messages))
+        last = items[-1]
+        assert last.is_complete()
+        if c.caller_count > 0:
+            assert len(last.callers) == c.caller_count
+            caller = last.callers[0]
+            assert caller.name == c.token, repr(c)
+            assert caller.arguments == c.arguments, repr(c)
+            assert last.content == c.output_content, repr(c)

--- a/tests/core/messages/test_functional_tokens.py
+++ b/tests/core/messages/test_functional_tokens.py
@@ -1,5 +1,5 @@
 from ghostos.core.messages import Message
-from ghostos.core.messages.pipeline import SequencePipe, pipeline
+from ghostos.core.messages.pipeline import SequencePipe, run_pipeline
 from ghostos.core.messages.functional_tokens import XMLFunctionalTokenPipe
 from ghostos.core.llms.tools import FunctionalToken
 
@@ -17,7 +17,7 @@ def test_xml_functional_token_pipe_baseline():
     for c in content:
         messages.append(Message.new_chunk(content=c))
 
-    items = list(pipeline([sequence_pipe, xml_ft_pipe], messages))
+    items = list(run_pipeline([sequence_pipe, xml_ft_pipe], messages))
     last = items[-1]
     assert last.is_complete()
     assert len(last.callers) == 1
@@ -44,7 +44,7 @@ def test_2_xml_functional_token_pipe():
     for c in content:
         messages.append(Message.new_chunk(content=c))
 
-    items = list(pipeline([sequence_pipe, xml_ft_pipe], messages))
+    items = list(run_pipeline([sequence_pipe, xml_ft_pipe], messages))
     last = items[-1]
     assert last.is_complete()
     assert len(last.callers) == 2
@@ -131,7 +131,7 @@ def test_xml_functional_token_pipe_cases():
         ft = FunctionalToken.new(token=c.token, visible=c.visible)
         sequence_pipe = SequencePipe()
         xml_ft_pipe = XMLFunctionalTokenPipe([ft])
-        items = list(pipeline([sequence_pipe, xml_ft_pipe], messages))
+        items = list(run_pipeline([sequence_pipe, xml_ft_pipe], messages))
         last = items[-1]
         assert last.is_complete()
         if c.caller_count > 0:

--- a/tests/core/messages/test_openai_parser.py
+++ b/tests/core/messages/test_openai_parser.py
@@ -4,7 +4,7 @@ from openai.types.chat.chat_completion_chunk import (
     ChoiceDeltaToolCall, ChoiceDeltaToolCallFunction,
 )
 from ghostos.core.messages.message import MessageType
-from ghostos.core.messages.pipeline import SequencePipe, pipeline
+from ghostos.core.messages.pipeline import SequencePipe, run_pipeline
 from ghostos.core.messages.transport import new_basic_connection
 
 
@@ -51,7 +51,7 @@ def test_openai_parser_bad_case_1():
     parser = DefaultOpenAIMessageParser(None, None)
     pipes = [SequencePipe(), SequencePipe(), SequencePipe()]
     messages = parser.from_chat_completion_chunks(items)
-    messages = list(pipeline(pipes, messages))
+    messages = list(run_pipeline(pipes, messages))
     assert len(messages) == len(items) + 2
 
     stream, receiver = new_basic_connection()

--- a/tests/core/messages/test_pipeline.py
+++ b/tests/core/messages/test_pipeline.py
@@ -1,6 +1,6 @@
 from typing import Iterable
 from ghostos.core.messages import Message
-from ghostos.core.messages.pipeline import SequencePipe, pipeline
+from ghostos.core.messages.pipeline import SequencePipe, run_pipeline
 
 
 def test_multi_sequence_pipes():
@@ -11,7 +11,7 @@ def test_multi_sequence_pipes():
             yield Message.new_chunk(content=char)
 
     messages = iter_content(content)
-    parsed = pipeline([SequencePipe(), SequencePipe(), SequencePipe()], messages)
+    parsed = run_pipeline([SequencePipe(), SequencePipe(), SequencePipe()], messages)
     got = list(parsed)
     assert len(got) == len(content) + 1
     assert got[0].is_head()


### PR DESCRIPTION

Features: 
* Restore the feature `functional token` for models that do not support function call.
  * add xml functional token pipe to parse output message chunks, generate `FunctionCaller` by functional tokens.
  * OpenAIAdapter now support functional token instructions and output parser.
* `deepseek-reasoner` now support functional token, so it can use MOSS protocol to execute python code.
  * support `last_message_shall_be_assistant_or_user` feature.
  * support `support_functional_tokens` feature.
* Session add `respond_buffer` method, send messages while saving, in case responding message between `function call` and `function output` which many models not support.
* Add `Replier` library for agent directly reply in the generated MOSS code.

Test cases:
* `ghostos web ghostos.demo.test_agents.deepseek_chat_func_tokens`
* `ghostos web ghostos.demo.test_agents.deepseek_chat_r1_func_tokens`

Small changes:
* move `ModelConf.use_tools` to `Compatible.function_call_use_tool`.
* add more options to llms `Compatible`, to compatible with the shitty features of various models. 
* rename `ghostos.core.message.pipeline.pipine` function to `run_pipeline`
* rename `MossAction.unmarshal_arguments` to `MossAction.unmarshal_code`
* streamlit app module `prompt` now display functional tokens info about prompt.

Breaking Changes:
* rename MossAgent attribute `instructions` to `instruction` 
* `ghostos web` now do not open browser as default (set streamlit app option `headless` to false as default)

Bug fixes:
* fix the `OpenAIAdapter` parsed prompt is not the same with the saved prompt.

