### PR TITLE
feat: ioc container supports auto dep injection.

### DIFF
--- a/tests/core/messages/test_arr_stream_receiver.py
+++ b/tests/core/messages/test_arr_stream_receiver.py
@@ -271,7 +271,7 @@ def test_array_receiver_bad_case_1():
             "name": "SpheroGPT",
             "content": "os",
             "memory": None,
-            "attrs": None,
+            "attrs": {},
             "payloads": {},
             "callers": [],
             "seq": "chunk",


### PR DESCRIPTION
## IOC容器支持自动管理依赖注入

### 修改前: 需要手动force_fetch依赖的容器，当依赖比较复杂的时候会很麻烦，比如下面的 make_B, make_C
>（见 tests/test_container.py: test_manual_inject_provider）
```python
    class ProviderA:
        def __init__(self):
            pass

        def dep_info(self):
            return "ProviderA depend nothing"

    class ProviderB:
        def __init__(self, A: ProviderA):
            self.A = A

        def dep_info(self):
            return f"ProviderB depend {self.A}"

    class ProviderC:
        def __init__(self, A: ProviderA, B: ProviderB, s: str):
            self.A = A
            self.B = B
            self.s = s

        def dep_info(self):
            return f"ProviderC depend {self.A} and {self.B} has {self.s}"

    @provide(ProviderA)
    def make_A(_):
        return ProviderA()

    @provide(ProviderB)
    def make_B(_):
        A = container.force_fetch(ProviderA)
        return ProviderB(A)

    @provide(ProviderC)
    def make_C(_, s:str="string"):
        A = container.force_fetch(ProviderA)
        B = container.force_fetch(ProviderB)
        return ProviderC(A, B, s)

    container = Container()
    container.register(make_A, make_B, make_C)
    c = container.force_fetch(ProviderC)
    print(c.dep_info())
```

### 修改后：在provide装饰器增加了autowire开关，开启后，可以自动管理和注入依赖
>（见 tests/test_container.py: test_auto_inject_provider）
```python
    class ProviderA:
        def __init__(self):
            pass

        def dep_info(self):
            return "ProviderA depend nothing"

    class ProviderB:
        def __init__(self, A: ProviderA):
            self.A = A

        def dep_info(self):
            return f"ProviderB depend {self.A}"

    class ProviderC:
        def __init__(self, A: ProviderA, B: ProviderB, s: str):
            self.A = A
            self.B = B
            self.s = s

        def dep_info(self):
            return f"ProviderC depend {self.A} and {self.B} has {self.s}"

    @provide(ProviderA, autowire=True)
    def make_A(_):
        return ProviderA()

    @provide(ProviderB, autowire=True)
    def make_B(_, A: ProviderA):
        return ProviderB(A)

    @provide(ProviderC, autowire=True)
    def make_C(_, A: ProviderA, B: ProviderB, s:str="string"):
        return ProviderC(A, B, s)

    container = Container()
    container.register(make_A, make_B, make_C)
    c = container.force_fetch(ProviderC)
    print(c.dep_info())
```

使用自动注入依赖(autowire=True)的时候，不能在开头加入 `from __future__ import annotations` ，这个会将依赖注解强制转为字符串，导致根据注解解析依赖失败。