### PR TITLE
feat: container add 'make' and 'call' method for dependencies injection

### DIFF
--- a/tests/core/messages/test_arr_stream_receiver.py
+++ b/tests/core/messages/test_arr_stream_receiver.py
@@ -271,7 +271,7 @@ def test_array_receiver_bad_case_1():
             "name": "SpheroGPT",
             "content": "os",
             "memory": None,
-            "attrs": None,
+            "attrs": {},
             "payloads": {},
             "callers": [],
             "seq": "chunk",

--- a/tests/framework/tasks/test_storage_impl.py
+++ b/tests/framework/tasks/test_storage_impl.py
@@ -39,7 +39,11 @@ def test_storage_tasks_impl():
     assert new_got != task
     assert new_got == new_turn
 
-    assert TaskBrief.from_task(task) == TaskBrief.from_task(new_got)
+    t1 = TaskBrief.from_task(task)
+    t2 = TaskBrief.from_task(new_got)
+    t1.created = t2.created
+    t1.updated = t2.updated
+    assert t1 == t2
 
 
 def test_storage_tasks_impl_lock():


### PR DESCRIPTION
Add automatically dependencies injection by arguments reflections, for class or function. 
Notice this is an experimental feature.  Python reflection is not prepared enough for auto dependencies injection.